### PR TITLE
Update style.css

### DIFF
--- a/app/View/Themed/Default/webroot/css/style.css
+++ b/app/View/Themed/Default/webroot/css/style.css
@@ -1,2 +1,59 @@
 /* style.css */
 
+.frame .nc-content-list article  h1,
+.frame .nc-content-list article  .h1,
+.frame .nc-content-list article  h2,
+.frame .nc-content-list article  .h2,
+.frame .nc-content-list article  h3,
+.frame .nc-content-list article  .h3 {
+  margin-top: 16px;
+  margin-bottom: 10px;
+}
+.frame .nc-content-list article  h4,
+.frame .nc-content-list article  .h4,
+.frame .nc-content-list article  h5,
+.frame .nc-content-list article  .h5,
+.frame .nc-content-list article  h6,
+.frame .nc-content-list article  .h6 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+.frame .nc-content-list article  h1 small,
+.frame .nc-content-list article  .h1 small,
+.frame .nc-content-list article  h2 small,
+.frame .nc-content-list article  .h2 small,
+.frame .nc-content-list article  h3 small,
+.frame .nc-content-list article  .h3 small,
+.frame .nc-content-list article  h1 .small,
+.frame .nc-content-list article  .h1 .small,
+.frame .nc-content-list article  h2 .small,
+.frame .nc-content-list article  .h2 .small,
+.frame .nc-content-list article  h3 .small,
+.frame .nc-content-list article  .h3 .small {
+  font-size: 75%;
+}
+
+.frame .nc-content-list article  h1,
+.frame .nc-content-list article  .h1 {
+  font-size: 27px;
+}
+.frame .nc-content-list article  h2,
+.frame .nc-content-list article  .h2 {
+  font-size: 18px;
+}
+.frame .nc-content-list article  h3,
+.frame .nc-content-list article  .h3 {
+  font-size: 16px;
+}
+.frame .nc-content-list article  h4,
+.frame .nc-content-list article  .h4 {
+  font-size: 13.5px;
+}
+.frame .nc-content-list article  h5,
+.frame .nc-content-list article  .h5 {
+  font-size: 10.5px;
+}
+.frame .nc-content-list article  h6,
+.frame .nc-content-list article  .h6 {
+  font-size: 9px;
+}


### PR DESCRIPTION
.frameの中にコンテンツ一覧を表示する場合、H2,H3を使用すると一覧の文字が大きすぎてバランスがおかしいことに対処。

コンテンツ一覧を表示する枠の要素に「nc-content-list」クラスを追加してください。
自動的に中に表示しているコンテンツ一覧に用いるタイトルのH2,H3などが、デフォルトの大きさより幾分小さめに表示されるようになります。