### PR TITLE
gjslintでwebroot/js/langsを除外する

### DIFF
--- a/tools/build/plugins/cakephp/travis/main.sh
+++ b/tools/build/plugins/cakephp/travis/main.sh
@@ -9,7 +9,7 @@ phpmd app/Plugin/$PLUGIN_NAME text /etc/phpmd/rules.xml --exclude $NETCOMMONS_BU
 phpcpd --exclude Test --exclude Config $IGNORE_PLUGINS_OPTS app/Plugin/$PLUGIN_NAME
 
 # js
-gjslint --strict -x jquery.js,jquery.cookie.js,js_debug_toolbar.js,travis.karma.conf.js,my.karma.conf.js -e jasmine_examples,HtmlPurifier,webroot/components -r app || exit $?
+gjslint --strict -x jquery.js,jquery.cookie.js,js_debug_toolbar.js,travis.karma.conf.js,my.karma.conf.js -e jasmine_examples,HtmlPurifier,webroot/components,webroot/js/langs -r app || exit $?
 if [ -d ./app/Plugin/$PLUGIN_NAME/JavascriptTest/ ]; then
   ./node_modules/karma/bin/karma start app/Plugin/$PLUGIN_NAME/JavascriptTest/travis.karma.conf.js --single-run --browsers PhantomJS || exit $?
 fi


### PR DESCRIPTION
tinymceの言語ファイルが、80文字制限を超えてしまうため、gjslintでwebroot/js/langsを除外する
