### PR TITLE
bower.json invalid-meta The "name"対応

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "NetCommons3",
+  "name": "net-commons3",
   "version": "3.0.0",
   "homepage": "http://www.netcommons.org/",
   "moduleType": [

--- a/tools/build/app/cakephp/pre.sh
+++ b/tools/build/app/cakephp/pre.sh
@@ -23,7 +23,7 @@ chmod -R 777 app/tmp
 mkdir -p build/logs
 
 sudo composer self-update
-composer update
+composer update --ignore-platform-reqs
 
 cp app/Config/database.php.$DB app/Config/database.php
 


### PR DESCRIPTION
```
$ bower install
bower                     invalid-meta for:/var/www/html/nc3/bower.json
bower                     invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes
```
invalid-metaの警告がでてもphp composer.phar install経由で動きました。
できれば修正した方がいいと思い、修正後に`$ php composer.phar install`でbower動いた事を確認しました。
