### PR TITLE
fix: MySQL5.7対応. sql_modeはデフォルト空を設定 

### DIFF
--- a/app/Config/database.php.install
+++ b/app/Config/database.php.install
@@ -75,6 +75,9 @@ class DATABASE_CONFIG {
 		'prefix' => '{master_prefix}',
 		'schema' => '{master_schema}',
 		'encoding' => '{master_encoding}',
+		'settings' => [
+			'@@SESSION.sql_mode' => "''",
+		],
 	);
 
 	public $slave1 = array(
@@ -88,6 +91,9 @@ class DATABASE_CONFIG {
 		'prefix' => '{master_prefix}',
 		'schema' => '{master_schema}',
 		'encoding' => '{master_encoding}',
+		'settings' => [
+			'@@SESSION.sql_mode' => "''",
+		],
 	);
 
 	public $test = array(
@@ -101,5 +107,8 @@ class DATABASE_CONFIG {
 		'prefix' => '{test_prefix}',
 		'schema' => '{test_schema}',
 		'encoding' => '{test_encoding}',
+		'settings' => [
+			'@@SESSION.sql_mode' => "''",
+		],
 	);
 }


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1262

機能改善の修正です。
トラビステスト通ったら、マージしようと思います。
動作確認済みです。

### 動作確認詳細

MYSQLの設定ファイルmy.cnfに、下記MYSQL5.7デフォルトの設定をして、netcommonsを新規インストール、#1262 に報告のあったエラーになる操作をしても、エラーにならない事を確認しました。
```
sql_mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION 
```
### sql_modeを空にした理由

レンタルサーバーで動かないためです。

また、sql_modeの設定は、主に、いままでゆるく登録できたものを、厳密にエラーにするような設定でしたので、空にしてもセキュリティが弱くなるような設定項目ではありませんでした。

#### 情報源
http://gihyo.jp/dev/serial/01/mysql-road-construction-news/0018
https://dev.mysql.com/doc/refman/5.6/ja/sql-mode.html

