### PR TITLE
fix: キャッシュのパフォーマンス改善

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -31,7 +31,7 @@
  * In production mode, flash messages redirect after a time interval.
  * In development mode, you need to click the flash message to continue.
  */
-	Configure::write('debug', 2);
+	Configure::write('debug', 0);
 
 /**
  * Configure the Error handler used to handle errors for your application. By default


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1337

パフォーマンス改善のプルリクエストです。
トラビステスト通ったら、マージしようと思ってます。

### 内容
https://github.com/NetCommons3/NetCommons3/blob/master/app/Config/core.php#L357-L359
debug=2だと、上記で10秒に変わってしまうため。

### 補足
開発時にtest.phpを利用する場合は、手動でdebug=2に変更すること。