### PR TITLE
fix: メンテナンスされなくなったパッケージの見直しphp-coveralls/php-coveralls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phploc/phploc":                "2.*@stable",
         "phpmd/phpmd" :                 "@stable",
         "phpunit/phpunit":              "*@stable",
-        "satooshi/php-coveralls":       "~1.0@stable",
+        "php-coveralls/php-coveralls":  "~1.0@stable",
         "sebastian/phpcpd":             "*@stable",
         "symfony/debug":                "2.8.*@stable",
         "symfony/dependency-injection": "2.8.*@stable",


### PR DESCRIPTION
php7.2テスト対応
https://github.com/NetCommons3/NetCommons3/issues/1451

トラビステスト通ったらマージしようと思ってます。

https://packagist.org/packages/satooshi/php-coveralls
> This package is abandoned and no longer maintained. The author suggests using the php-coveralls/php-coveralls package instead.
> (google翻訳)このパッケージは放棄され、メンテナンスされなくなりました。 著者は代わりにphp-coveralls / php-coverallsパッケージを使うことを提案します。

https://packagist.org/packages/php-coveralls/php-coveralls

