### PR TITLE
feat: composer v2に対応

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,10 @@
     ],
     "config": {
         "vendor-dir": "vendors",
-        "process-timeout": 3000
+        "process-timeout": 3000,
+        "allow-plugins": {
+            "composer/installers": true
+        }
     },
     "scripts": {
         "post-install-cmd": ["app/Console/cake install.install install_bower"],


### PR DESCRIPTION
Composer v1が2025年8月でサポートが終了するため、Composer v2に対応するよう修正
開発環境にする際は、composer.jsonに下記を付与する。
```
composer config minimum-stability dev
composer config preferred-install.netcommons/* source
```

参考：Composer v2へのアップデート
```
composer self-update --2
```